### PR TITLE
use service name of istiocoredns (k8s>=1.15.1)

### DIFF
--- a/istio-multi-controlplane-with-mesh-expansion/istio/dnsconfigmap.yaml
+++ b/istio-multi-controlplane-with-mesh-expansion/istio/dnsconfigmap.yaml
@@ -19,4 +19,4 @@ metadata:
   namespace: kube-system
 data:
   stubDomains: |
-    {"global": ["$(kubectl get svc -n istio-system istiocoredns -o jsonpath={.spec.clusterIP})"]}
+    {"global": ["istiocoredns.istio-system.svc.cluster.local"]}

--- a/istio-multi-controlplane/istio/dnsconfigmap.yaml
+++ b/istio-multi-controlplane/istio/dnsconfigmap.yaml
@@ -19,4 +19,4 @@ metadata:
   namespace: kube-system
 data:
   stubDomains: |
-    {"global": ["$(kubectl get svc -n istio-system istiocoredns -o jsonpath={.spec.clusterIP})"]}
+    {"global": ["istiocoredns.istio-system.svc.cluster.local"]}


### PR DESCRIPTION
For the users k8s>=1.15.1 can use service name for stub domain to not struggle doing automation 