### PR TITLE
Removing redis-cart service

### DIFF
--- a/anthos-multicloud/online-boutique/control/services-all.yaml
+++ b/anthos-multicloud/online-boutique/control/services-all.yaml
@@ -131,19 +131,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: redis-cart
-spec:
-  type: ClusterIP
-  selector:
-    app: redis-cart
-  ports:
-  - name: redis
-    port: 6379
-    targetPort: 6379
----
-apiVersion: v1
-kind: Service
-metadata:
   name: adservice
 spec:
   type: ClusterIP


### PR DESCRIPTION
Service has no deployments and is not used.